### PR TITLE
Add wait action in Look Mode

### DIFF
--- a/scripts/player/states/look_mode_state.gd
+++ b/scripts/player/states/look_mode_state.gd
@@ -103,8 +103,14 @@ func handle_input(event: InputEvent) -> void:
 
 	# Block all other inputs while in look mode
 	# (Camera rotation handled by FirstPersonCamera directly)
+	# (RT/LMB handled in process_frame via InputManager)
 
 func process_frame(_delta: float) -> void:
+	# Handle RT/LMB for wait action (using InputManager for proper action tracking)
+	if InputManager and InputManager.is_action_just_pressed("move_confirm"):
+		_execute_wait_action()
+		return
+
 	# Update raycast and examination target (uses examination overlay system)
 	if not first_person_camera:
 		return
@@ -126,5 +132,24 @@ func process_frame(_delta: float) -> void:
 			# Looking at nothing
 			if examination_ui:
 				examination_ui.hide_panel()
+
+# ============================================================================
+# ACTIONS
+# ============================================================================
+
+func _execute_wait_action() -> void:
+	"""Execute a wait action (pass turn without moving) while staying in look mode"""
+	var wait_action = WaitAction.new()
+
+	Log.turn("[Look Mode] Player waiting (passing turn)")
+
+	# Execute the wait action directly (stay in look mode, don't transition)
+	if wait_action.can_execute(player):
+		wait_action.execute(player)
+
+		# TODO: Process enemy turns when enemy system is implemented
+		# TODO: Process environmental effects when physics system is implemented
+
+		Log.turn("===== TURN %d COMPLETE (from Look Mode) =====" % player.turn_count)
 
 # All target handling now unified - no special cases for grid tiles vs entities


### PR DESCRIPTION
## Summary

Implements the ability to progress turns while remaining in Look Mode examination view.

- Press RT/Space/LMB while in Look Mode to execute a wait action
- Player stays in Look Mode and maintains position
- Turn counter increments by 1
- Enables tactical waiting while observing environment

## Changes

- Added `_execute_wait_action()` method to LookModeState
- Uses `InputManager.is_action_just_pressed()` for proper single-press detection
- Executes WaitAction directly without state transition (stays in Look Mode)
- Follows same input handling pattern as IdleState

## Input Parity

✅ RT (gamepad trigger)  
✅ Space (keyboard)  
✅ LMB (mouse click)

All handled via InputManager action system.

## Testing

- [x] Single press triggers wait action once (no repeats from holding/trigger drift)
- [x] Player stays in Look Mode after wait
- [x] Player position unchanged after wait
- [x] Turn counter increments correctly
- [x] Works with all input methods (RT/Space/LMB)

## Future Integration

Includes TODO markers for:
- Enemy AI turn processing
- Environmental effects processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)