### PR TITLE
fix: Controller pause input and HUD focus issues

### DIFF
--- a/scripts/player/player_3d.gd
+++ b/scripts/player/player_3d.gd
@@ -162,6 +162,10 @@ func _unhandled_input(event: InputEvent) -> void:
 		state_machine.handle_input(event)
 
 func _process(delta: float) -> void:
+	# Block gameplay processing when paused (UI navigation takes over)
+	if PauseManager and PauseManager.is_paused:
+		return
+
 	# Delegate to state machine
 	if state_machine:
 		state_machine.process_frame(delta)

--- a/scripts/player/tactical_camera.gd
+++ b/scripts/player/tactical_camera.gd
@@ -65,6 +65,11 @@ func _ready() -> void:
 		Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
 
 func _process(delta: float) -> void:
+	# Block camera movement when paused (UI navigation takes over)
+	if PauseManager and PauseManager.is_paused:
+		mouse_motion_accumulator = Vector2.ZERO  # Clear any accumulated motion
+		return
+
 	# Apply accumulated mouse motion (from _unhandled_input)
 	# Averaging across events filters Firefox's systematic rounding drift
 	if mouse_motion_accumulator.length_squared() > MOTION_SAMPLE_THRESHOLD:


### PR DESCRIPTION
## Summary
- Fix RT/right stick input leaking to game when paused (was triggering movement/camera rotation)
- Fix HUD focus grab by passing actual `from_gamepad` flag through pause chain instead of relying on stale device state
- Fix invisible GameOverPanel button being incorrectly focused by checking full ancestor visibility chain

## Known Issue (Not Fixed)
Firefox on Linux in windowed mode has a pointer lock bug causing camera to swing up uncontrollably. This is a [known Firefox browser bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1739598) with no code-level workaround. Workarounds: use Chrome, use fullscreen, or use a controller.

## Test plan
- [x] Pause with controller (Start) - HUD should get focus, right stick navigates UI
- [x] RT while paused - should NOT trigger movement
- [x] Right stick while paused - should NOT rotate camera
- [x] Mouse hover while paused - HUD elements highlight correctly
- [x] GameOverPanel button not focused when panel is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)