### PR TITLE
fix: Resolve export-only examination bug

### DIFF
--- a/scripts/autoload/knowledge_db.gd
+++ b/scripts/autoload/knowledge_db.gd
@@ -1,6 +1,10 @@
 extends Node
 ## KnowledgeDB - Singleton for tracking player knowledge and discoveries
 ##
+## NOTE: LevelManager const access uses a runtime method call (get_preloaded_configs())
+## instead of direct const access because Godot's bytecode compiler can't resolve
+## const members on autoload-only scripts (no class_name) at compile time.
+##
 ## This autoload handles:
 ## - Novelty tracking per Clearance level (for EXP rewards)
 ## - Clearance level tracking (now managed by Player's StatBlock)
@@ -199,7 +203,7 @@ func _get_item_by_id(item_id: String) -> Item:
 				return item
 
 	# Search all preloaded level configs (for cross-level items)
-	for level_config in LevelManager.PRELOADED_CONFIGS.values():
+	for level_config in LevelManager.get_preloaded_configs().values():
 		if level_config == current_level:
 			continue  # Already searched
 		for item in level_config.permitted_items:

--- a/scripts/autoload/level_manager.gd
+++ b/scripts/autoload/level_manager.gd
@@ -192,6 +192,10 @@ func transition_to_level(target_level_id: int) -> void:
 func get_current_level() -> LevelConfig:
 	return _current_level
 
+## Get preloaded level configs (runtime accessor for bytecode export compatibility)
+func get_preloaded_configs() -> Dictionary:
+	return PRELOADED_CONFIGS
+
 ## Check if a level is loaded in cache
 func is_level_cached(level_id: int) -> bool:
 	return _level_cache.has(level_id)


### PR DESCRIPTION
## Summary
- Examining entities in exported builds showed "Unknown" / "[DATA EXPUNGED]" instead of actual text
- Root cause: `LevelManager.PRELOADED_CONFIGS` const access fails in bytecode exports because `LevelManager` has no `class_name` — Godot's compiler can't resolve const members on autoload-only scripts at compile time
- Latent bug introduced in v0.8.2's codex cross-level fix, exposed when dead code removal forced recompilation
- Fix: replace direct const access with runtime method call `get_preloaded_configs()`

## Test plan
- [x] `godot --headless --quit` passes
- [x] Linux export build: examination shows correct entity names/descriptions
- [ ] Web export build: examination works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)