### PR TITLE
docs: Add achievement brainstorming doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1348,4 +1348,6 @@ VERSION=$(git describe --tags --abbrev=0)
 
 **Test before commit** - seriously, this is the most important lesson. User will tell you when they're ready to commit.
 
+**Steam integration is a future goal** - achievement ideas are tracked in `docs/achievement_brainstorming.md`. GodotSteam GDExtension will be the integration path when the time comes.
+
 **Investigate the truth!** - the codebase itself is the best source of truth in the repo. Before major changes, make sure you read all the files you need to, in full, to get as much appropriate context as possible prior to planning.

--- a/docs/achievement_brainstorming.md
+++ b/docs/achievement_brainstorming.md
@@ -1,0 +1,7 @@
+# Achievement Brainstorming
+
+Ideas for Steam achievements. Not all of these will make it — just a place to capture them.
+
+## Tutorial
+
+- **Pacifist** — Leave the tutorial level without killing the mannequin


### PR DESCRIPTION
## Summary
- Adds `docs/achievement_brainstorming.md` to start tracking Steam achievement ideas
- Notes future Steam/GodotSteam integration plans in CLAUDE.md

No code changes — just planning docs for eventual Steam release.

## Test plan
- N/A (documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)