### PR TITLE
fix: Auto-explore UX polish + entropy-locked light flickering

### DIFF
--- a/scripts/ai/behaviors/behavior_registry.gd
+++ b/scripts/ai/behaviors/behavior_registry.gd
@@ -42,7 +42,6 @@ func _init_behaviors() -> void:
 		"vending_machine": _VendingMachineBehavior.new(),
 		"exit_hole": _ExitHoleBehavior.new(),
 		"fluorescent_light": _LightFixtureBehavior.new(),
-		"fluorescent_light_broken": _LightFixtureBehavior.new(),
 		"barrel_fire": _BarrelFireBehavior.new(),
 	}
 

--- a/scripts/ai/behaviors/light_fixture_behavior.gd
+++ b/scripts/ai/behaviors/light_fixture_behavior.gd
@@ -1,6 +1,37 @@
 class_name LightFixtureBehavior extends EntityBehavior
-## Behavior for stationary light fixtures (fluorescent lights, broken lights)
-## Does nothing — purely environmental entities
+## Behavior for fluorescent light fixtures — entropy-locked flicker system
+##
+## Each light gets a unique personality (reseed_threshold + on_weight) rolled
+## at spawn from its world position hash. The entropy lock produces stable
+## patterns that occasionally break and reform — recognizable but unpredictable.
+##
+## Personality spectrum:
+##   reseed_threshold high + on_weight high → steady, rarely flickers off
+##   reseed_threshold low + on_weight ~0.5 → chaotic, unpredictable
+##   reseed_threshold high + on_weight low → stably off, rare brief spark
 
 func _init() -> void:
 	skip_turn_processing = true
+
+static func setup_flicker(entity: WorldEntity) -> void:
+	"""Stamp entropy lock personality onto a light entity at spawn.
+
+	Uses the entity's world position as a deterministic seed so the same
+	light always gets the same personality in the same world.
+
+	Args:
+		entity: The fluorescent light entity
+	"""
+	var rng := RandomNumberGenerator.new()
+	rng.seed = hash(entity.world_position)
+
+	entity.on_weight = rng.randf()
+	entity.reseed_threshold = rng.randf()
+
+	# Each light gets its own RNG instance for the entropy lock
+	entity.flicker_rng = RandomNumberGenerator.new()
+	entity.flicker_seed = rng.randi()
+	entity.flicker_rng.seed = entity.flicker_seed
+
+	# Evaluate initial state
+	entity.flicker_on = entity.flicker_rng.randf() < entity.on_weight

--- a/scripts/autoload/entity_registry.gd
+++ b/scripts/autoload/entity_registry.gd
@@ -264,20 +264,6 @@ func _load_entities() -> void:
 	fluorescent_light.blocks_movement = false
 	_entities["fluorescent_light"] = fluorescent_light
 
-	# Fluorescent Light — Broken (Level 0 dark variant, no light emission)
-	var fluorescent_light_broken = EntityInfo.new()
-	fluorescent_light_broken.entity_id = "fluorescent_light_broken"
-	fluorescent_light_broken.entity_name = "Broken Light"
-	fluorescent_light_broken.visual_description = "A dead fluorescent fixture. The tube is dark — either burnt out or shattered. Fragments of glass and phosphor dust litter the ceiling panel."
-	fluorescent_light_broken.clearance_info[0] = ""
-	fluorescent_light_broken.clearance_info[1] = "No electrical activity detected. The tube appears to have failed naturally, though 'naturally' is a generous term here."
-	fluorescent_light_broken.clearance_info[2] = "Areas with broken fixtures tend to cluster together. Whether this is coincidence or something deliberate is unclear."
-	fluorescent_light_broken.object_class = "Safe"
-	fluorescent_light_broken.threat_level = 0
-	fluorescent_light_broken.hostile = false
-	fluorescent_light_broken.blocks_movement = false
-	_entities["fluorescent_light_broken"] = fluorescent_light_broken
-
 	# Barrel Fire (Level -1 ground-level light source)
 	var barrel_fire = EntityInfo.new()
 	barrel_fire.entity_id = "barrel_fire"

--- a/scripts/autoload/exploration_tracker.gd
+++ b/scripts/autoload/exploration_tracker.gd
@@ -131,6 +131,11 @@ func mark_item_dismissed(pos: Vector2i) -> void:
 func is_item_dismissed(pos: Vector2i) -> bool:
 	return dismissed_items.has(pos)
 
+func invalidate_target() -> void:
+	"""Clear cached BFS target, forcing a fresh search from the player's current position.
+	Called when auto-explore is cancelled so re-entry doesn't path to the old destination."""
+	_cached_target = NO_TARGET
+
 func reset() -> void:
 	explored_tiles.clear()
 	visited_vending_machines.clear()

--- a/scripts/autoload/exploration_tracker.gd
+++ b/scripts/autoload/exploration_tracker.gd
@@ -116,7 +116,6 @@ func _bfs_find_unexplored(from: Vector2i, restrict_chunk: Vector2i) -> Vector2i:
 func is_explored(pos: Vector2i) -> bool:
 	return explored_tiles.has(pos)
 
-## Reset all exploration data (called on level change)
 func mark_vending_machine_visited(pos: Vector2i) -> void:
 	"""Mark a vending machine as visited so auto-explore won't stop for it again."""
 	visited_vending_machines[pos] = true
@@ -136,6 +135,7 @@ func invalidate_target() -> void:
 	Called when auto-explore is cancelled so re-entry doesn't path to the old destination."""
 	_cached_target = NO_TARGET
 
+## Reset all exploration data (called on level change)
 func reset() -> void:
 	explored_tiles.clear()
 	visited_vending_machines.clear()

--- a/scripts/game_3d.gd
+++ b/scripts/game_3d.gd
@@ -36,6 +36,7 @@ extends Node3D
 
 var snowfall: Snowfall = null
 var chunk_indicator: ChunkLoadingIndicator = null
+var control_hints: ControlHints = null
 var void_plane: MeshInstance3D = null
 
 ## Y position for the void-fill plane (empirically confirmed, see CLAUDE.md)
@@ -86,6 +87,10 @@ func _ready() -> void:
 	# Chunk loading indicator (in-viewport overlay)
 	chunk_indicator = ChunkLoadingIndicator.new()
 	$ViewportUILayer.add_child(chunk_indicator)
+
+	# Persistent MOVE/WAIT control hints
+	control_hints = ControlHints.new()
+	$ViewportUILayer.add_child(control_hints)
 
 	# Create void-fill plane after initial chunks load
 	if ChunkManager and not ChunkManager.initial_load_completed.is_connected(_create_void_plane):

--- a/scripts/grid_3d.gd
+++ b/scripts/grid_3d.gd
@@ -762,10 +762,10 @@ func _init_lightmap() -> void:
 
 
 func _rebuild_lightmap() -> void:
-	"""Rebuild lightmap: fill with ambient, splat all fixture lights, upload to GPU.
+	"""Rebuild lightmap: clear to black, splat fixture light contributions, upload to GPU.
 
-	Called from _process() when _lightmap_dirty is true (chunk load/unload).
-	Centers the lightmap on the current player position.
+	Called from _process() when _lightmap_dirty is true (chunk load/unload,
+	flicker state change). Centers the lightmap on the current player position.
 	"""
 	if not player_node or not entity_renderer:
 		return

--- a/scripts/player/states/auto_explore_state.gd
+++ b/scripts/player/states/auto_explore_state.gd
@@ -63,8 +63,9 @@ func enter() -> void:
 	if player and player.stats:
 		hp_before_step = player.stats.current_hp
 
-	# Show HUD indicator
+	# Show HUD indicator, hide control hints (MOVE/WAIT not relevant during auto-explore)
 	_show_hud_indicator(true)
+	_set_control_hints_visible(false)
 
 	# Mark current position as explored
 	_mark_current_explored()
@@ -113,6 +114,7 @@ func enter() -> void:
 func exit() -> void:
 	super.exit()
 	_show_hud_indicator(false)
+	_set_control_hints_visible(true)
 
 # ============================================================================
 # INPUT - Any input cancels auto-explore
@@ -274,9 +276,11 @@ func process_frame(delta: float) -> void:
 		waiting_for_turn = true
 		transition_to("PreTurnState")
 	else:
-		# Movement blocked — clear path and try again next frame
-		Log.state("Auto-explore: Movement blocked, recalculating path")
-		_clear_cached_path()
+		# Movement blocked — cancel auto-explore entirely
+		Log.state("Auto-explore: Movement blocked, cancelling")
+		Log.player("Auto-explore stopped: path blocked")
+		transition_to("IdleState")
+		return
 
 # ============================================================================
 # STOP CONDITIONS
@@ -587,6 +591,14 @@ func _rotate_camera_to_direction(direction: Vector2i) -> void:
 	# Also sync tactical camera
 	if player.camera_rig:
 		tween.tween_property(player.camera_rig.h_pivot, "rotation_degrees:y", final_yaw, 0.15).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
+
+func _set_control_hints_visible(is_visible: bool) -> void:
+	"""Show or hide the persistent MOVE/WAIT control hints"""
+	if not player:
+		return
+	var game_3d = player.get_parent()
+	if game_3d and game_3d.control_hints:
+		game_3d.control_hints.visible = is_visible
 
 func _show_hud_indicator(visible: bool) -> void:
 	"""Show or hide the AUTO-EXPLORE HUD indicator"""

--- a/scripts/player/states/auto_explore_state.gd
+++ b/scripts/player/states/auto_explore_state.gd
@@ -115,6 +115,11 @@ func exit() -> void:
 	super.exit()
 	_show_hud_indicator(false)
 	_set_control_hints_visible(true)
+	# Only clear cached state on actual cancellation (not turn transitions).
+	# During a turn, waiting_for_turn is true — we want to preserve the path.
+	if not waiting_for_turn:
+		_clear_cached_path()
+		ExplorationTracker.invalidate_target()
 
 # ============================================================================
 # INPUT - Any input cancels auto-explore

--- a/scripts/procedural/level_0_generator.gd
+++ b/scripts/procedural/level_0_generator.gd
@@ -536,8 +536,6 @@ func _place_doors(grid: Array, rng: RandomNumberGenerator) -> void:
 ## 5 tiles = 10 world units between lights. With range 12, adjacent lights
 ## overlap significantly for dense fluorescent coverage.
 const LIGHT_SPACING := 5
-## Probability that a light fixture is broken (dark, no light emission)
-const LIGHT_BROKEN_CHANCE := 0.15
 ## Random offset range for light positions (prevents perfectly regular grid)
 const LIGHT_JITTER := 1
 
@@ -545,7 +543,7 @@ func _place_lights(grid: Array, chunk: Chunk, rng: RandomNumberGenerator) -> voi
 	"""Place fluorescent ceiling light entities on walkable floor tiles.
 
 	Uses a regular grid with jitter for natural-looking coverage.
-	Some fixtures are broken (no light emission) to create dark areas.
+	Each light gets a unique entropy-locked personality from its world position.
 	"""
 	var chunk_world := chunk.position * Chunk.SIZE
 	var light_count := 0
@@ -560,10 +558,10 @@ func _place_lights(grid: Array, chunk: Chunk, rng: RandomNumberGenerator) -> voi
 				continue
 
 			var world_pos := Vector2i(x, y) + chunk_world
-			var entity_type := "fluorescent_light_broken" if rng.randf() < LIGHT_BROKEN_CHANCE else "fluorescent_light"
 
-			var light_entity := WorldEntity.new(entity_type, world_pos, 99999.0, 0)
+			var light_entity := WorldEntity.new("fluorescent_light", world_pos, 99999.0, 0)
 			EntityRegistry.apply_defaults(light_entity)
+			LightFixtureBehavior.setup_flicker(light_entity)
 
 			var sc := chunk.get_sub_chunk(Vector2i(x / SubChunk.SIZE, y / SubChunk.SIZE))
 			if sc:

--- a/scripts/ui/control_hints.gd
+++ b/scripts/ui/control_hints.gd
@@ -12,7 +12,7 @@ extends Control
 # CONSTANTS
 # ============================================================================
 
-## Gamepad labels (from CONTROL_MAPPINGS in settings_panel.gd)
+## Control labels — keep in sync with CONTROL_MAPPINGS in settings_panel.gd
 const GAMEPAD_MOVE := "🎮 RT"
 const GAMEPAD_WAIT := "🎮 LT"
 

--- a/scripts/ui/control_hints.gd
+++ b/scripts/ui/control_hints.gd
@@ -1,0 +1,87 @@
+class_name ControlHints
+extends Control
+## Persistent MOVE/WAIT control hints at the top of the game viewport
+##
+## Shows the two core actions (Move Forward, Wait/Pass Turn) with input labels
+## that automatically switch between gamepad and keyboard+mouse glyphs based
+## on the active input device.
+##
+## Hidden during auto-explore (the AUTO-EXPLORE label takes that space).
+
+# ============================================================================
+# CONSTANTS
+# ============================================================================
+
+## Gamepad labels (from CONTROL_MAPPINGS in settings_panel.gd)
+const GAMEPAD_MOVE := "🎮 RT"
+const GAMEPAD_WAIT := "🎮 LT"
+
+## Keyboard+mouse labels
+const KB_MOVE := "🖱 LMB"
+const KB_WAIT := "🖱 RMB"
+
+const FONT_SIZE := 16
+const HINT_SPREAD := 120  # Pixels from center to each hint
+
+# ============================================================================
+# STATE
+# ============================================================================
+
+var move_label: Label
+var wait_label: Label
+
+# ============================================================================
+# LIFECYCLE
+# ============================================================================
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	set_anchors_preset(Control.PRESET_FULL_RECT)
+
+	# MOVE hint — left of center
+	move_label = _create_hint_label()
+	move_label.set_anchors_preset(Control.PRESET_CENTER_TOP)
+	move_label.offset_top = 4
+	move_label.offset_left = -HINT_SPREAD - 120
+	move_label.offset_right = -HINT_SPREAD + 40
+	move_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	add_child(move_label)
+
+	# WAIT hint — right of center
+	wait_label = _create_hint_label()
+	wait_label.set_anchors_preset(Control.PRESET_CENTER_TOP)
+	wait_label.offset_top = 4
+	wait_label.offset_left = HINT_SPREAD - 40
+	wait_label.offset_right = HINT_SPREAD + 120
+	wait_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+	add_child(wait_label)
+
+	_update_labels()
+
+	# Listen for input device changes
+	if InputManager:
+		InputManager.input_device_changed.connect(_on_input_device_changed)
+
+func _create_hint_label() -> Label:
+	var label := Label.new()
+	label.add_theme_font_size_override("font_size", FONT_SIZE)
+	label.add_theme_color_override("font_color", Color(0.7, 0.7, 0.65, 0.8))
+	label.add_theme_color_override("font_shadow_color", Color(0, 0, 0, 0.7))
+	label.add_theme_constant_override("shadow_offset_x", 1)
+	label.add_theme_constant_override("shadow_offset_y", 1)
+	label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	return label
+
+# ============================================================================
+# UPDATES
+# ============================================================================
+
+func _update_labels() -> void:
+	var is_gamepad := InputManager and InputManager.current_input_device == InputManager.InputDevice.GAMEPAD
+	var move_key := GAMEPAD_MOVE if is_gamepad else KB_MOVE
+	var wait_key := GAMEPAD_WAIT if is_gamepad else KB_WAIT
+	move_label.text = "MOVE  %s" % move_key
+	wait_label.text = "WAIT  %s" % wait_key
+
+func _on_input_device_changed(_device) -> void:
+	_update_labels()

--- a/scripts/ui/control_hints.gd.uid
+++ b/scripts/ui/control_hints.gd.uid
@@ -1,0 +1,1 @@
+uid://c3webc45nd0vc

--- a/scripts/ui/minimap.gd
+++ b/scripts/ui/minimap.gd
@@ -626,7 +626,7 @@ func _draw_entities(player_pos: Vector2i) -> void:
 
 	# Entity types to skip on minimap (environmental fixtures, too numerous to render)
 	const MINIMAP_HIDDEN_ENTITIES := [
-		"fluorescent_light", "fluorescent_light_broken", "barrel_fire",
+		"fluorescent_light", "barrel_fire",
 	]
 
 	for entity_pos in entity_positions:

--- a/scripts/world/entity_renderer.gd
+++ b/scripts/world/entity_renderer.gd
@@ -135,7 +135,7 @@ const ENTITY_HEIGHT_OVERRIDES = {
 	"vending_machine": 2.5,    # Tall machine, raised to match scale
 	"fluorescent_light": 4.4,  # Ceiling surface (empirically confirmed)
 	"fluorescent_light_broken": 4.4,
-	"barrel_fire": 1.0,        # Ground level (default billboard height)
+	"barrel_fire": 1.4,        # Slightly raised so barrel sits on ground naturally
 }
 
 ## Animated entity spritesheets — entities with frame-by-frame animation.

--- a/scripts/world/world_entity.gd
+++ b/scripts/world/world_entity.gd
@@ -94,6 +94,9 @@ var faction: String = ""
 # ============================================================================
 # PROPERTIES - Flicker State (entropy-locked light fixtures)
 # ============================================================================
+# NOTE: Not serialized in to_dict(). Personality is deterministic from
+# hash(world_position) via LightFixtureBehavior.setup_flicker(), so it
+# reconstructs identically without persistence.
 
 ## Whether this light is currently on (emitting light, lit texture).
 ## Only meaningful for entities with flicker_rng set up.

--- a/scripts/world/world_entity.gd
+++ b/scripts/world/world_entity.gd
@@ -92,6 +92,30 @@ var is_exit: bool = false
 var faction: String = ""
 
 # ============================================================================
+# PROPERTIES - Flicker State (entropy-locked light fixtures)
+# ============================================================================
+
+## Whether this light is currently on (emitting light, lit texture).
+## Only meaningful for entities with flicker_rng set up.
+var flicker_on: bool = true
+
+## Per-entity seeded RNG for entropy locking.
+## null for non-flickering entities.
+var flicker_rng: RandomNumberGenerator = null
+
+## The entropy lock's current seed. Reset to this each tick for deterministic output.
+## Probabilistic reseeding breaks the pattern and creates new stable states.
+var flicker_seed: int = 0
+
+## How likely the seed is to hold each tick. High = stable patterns, low = chaotic.
+## Range [0.0, 1.0]. If randf() > reseed_threshold, seed resets.
+var reseed_threshold: float = 0.85
+
+## Probability of being ON at each evaluation. High = mostly on, low = mostly off.
+## Range [0.0, 1.0]. flicker_on = randf() < on_weight.
+var on_weight: float = 0.9
+
+# ============================================================================
 # INITIALIZATION
 # ============================================================================
 


### PR DESCRIPTION
## Summary

- **Fix #65**: Auto-explore cancels entirely when movement is blocked (instead of infinite recalculation loop)
- **Fix #70**: Persistent MOVE/WAIT control hints at top of viewport, auto-switches gamepad/keyboard labels
- **Fix #64**: Entropy-locked procedural light flickering — each fluorescent light gets a unique personality from its world position hash

Also: auto-explore now paths from current position after cancel/re-activate (was remembering stale destination), barrel fire height adjusted from 1.0 to 1.4.

## Entropy Locking

Each light gets two parameters rolled from `hash(world_position)`:
- **on_weight** (0.0–1.0): probability of being ON at each evaluation
- **reseed_threshold** (0.0–1.0): probability of the RNG seed holding each tick

The entropy lock produces deterministic sequences between reseeds. Most lights settle into a permanent state (always on or always off) — only lights with mid-range parameters visibly flicker, and each one does so uniquely. Computationally near-free (~1 Hz tick, lightmap rebake only when a light changes state).

Unifies `fluorescent_light` and `fluorescent_light_broken` into a single entity type with a continuous personality spectrum.

## PR Review Notes

Full review ran with code-reviewer, comment-analyzer, silent-failure-hunter, and type-design-analyzer agents. Key findings:

**To address post-merge:**
- `tick_flicker()` mutates entity state inside EntityRenderer (documented as "RENDER-ONLY") — should move state mutation to `LightFixtureBehavior` or `WorldEntity`
- `_rebuild_lightmap()` docstring is stale (says "fill with ambient", code fills with black)
- Control hints duplicate label strings from `settings_panel.gd` CONTROL_MAPPINGS

**By design (not bugs):**
- Entropy lock settles permanently for most lights — this IS the intended behavior. Only lights with low `reseed_threshold` keep flickering. The emergent distribution of mostly-stable + few-chaotic lights creates natural-feeling realism.
- Flicker state not serialized in `to_dict()` — personality is deterministic from `hash(world_position)`, so it reconstructs identically.

## Test plan

- [x] Auto-explore cancels when blocked by entity
- [x] Auto-explore paths from current position after cancel + manual walk + re-activate
- [x] Control hints visible in idle, hidden during auto-explore, switch labels on device change
- [x] Fluorescent lights flicker with unique personalities (most stable, few chaotic)
- [x] Lightmap updates when lights change state (dark areas around off lights)
- [x] Barrel fire height looks natural
- [x] Headless validation passes (no script errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)